### PR TITLE
Use std::unique_ptr for memory managment of readers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(omnireader LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 if (${BUILD_PYTHON})
     find_package(PythonExtensions REQUIRED)

--- a/libomnireader/include/omnireader.h
+++ b/libomnireader/include/omnireader.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <cstring>
+#include <memory>
 
 namespace OmniReader {
 
@@ -67,7 +68,7 @@ namespace OmniReader {
         virtual inline unsigned long long fill_page(unsigned long long remainder) = 0;
     };
 
-    Reader *GetReader(Format option);
+    std::unique_ptr<Reader> GetReader(Format option);
 }
 
 #endif //OMNIREADER_OMNIREADER_H

--- a/libomnireader/src/omnireader.cpp
+++ b/libomnireader/src/omnireader.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 
 #include "omnireader.h"
 
@@ -104,14 +105,14 @@ namespace OmniReader {
 #include "GZReader.h"
 
 namespace OmniReader {
-    Reader *GetReader(OmniReader::Format option) {
+    std::unique_ptr<Reader> GetReader(OmniReader::Format option) {
       switch (option) {
         case OmniReader::Format::PlainText:
-          return new PlainTextReader();
+          return  std::make_unique<PlainTextReader>(PlainTextReader());
         case OmniReader::Format::BZ2:
-          return new BZ2Reader();
+          return std::make_unique<BZ2Reader>(BZ2Reader());
         case OmniReader::Format::GZ:
-          return new GZReader();
+          return std::make_unique<GZReader>(GZReader());
         default:
           return nullptr;
       }

--- a/libomnireader/test/test_lines.cpp
+++ b/libomnireader/test/test_lines.cpp
@@ -9,7 +9,7 @@
 
 using namespace OmniReader;
 
-std::vector<int> PrintLines(Reader* r) {
+std::vector<int> PrintLines( const std::unique_ptr<Reader> &r) {
   std::vector<int> lengths;
 
   while (!r->at_eof()) {
@@ -48,33 +48,30 @@ int main(int argc, char* argv[]) {
 
   const char* fname = argv[1];
 
-  OmniReader::Reader* r1 = GetReader(Format::PlainText);
+  auto r1 = GetReader(Format::PlainText);
   if (!r1->open(fname)) {
     fprintf(stderr, "Failed to open file: %s\n", argv[1]);
     return 1;
   }
   std::vector<int> ref_lengths = PrintLines(r1);
-  delete r1;
 
   std::string bz2fname(fname);
   bz2fname.append(".bz2");
-  OmniReader::Reader* r2 = GetReader(Format::BZ2);
+  auto r2 = GetReader(Format::BZ2);
   if (!r2->open(bz2fname.c_str())) {
     fprintf(stderr, "Failed to open bz2 file\n");
     return 1;
   }
   std::vector<int> bz2_lengths = PrintLines(r2);
-  delete r2;
 
   std::string gzfname(fname);
   gzfname.append(".gz");
-  OmniReader::Reader* r3 = GetReader(Format::GZ);
+  auto r3 = GetReader(Format::GZ);
   if (!r3->open(gzfname.c_str())) {
     fprintf(stderr, "Failed to open gz file\n");
     return 1;
   }
   std::vector<int> gz_lengths = PrintLines(r3);
-  delete r3;
 
   if (!compare_lengths(ref_lengths, gz_lengths)) {
     fputs("Failed for GZip\n", stderr);

--- a/libomnireader/test/test_seekntell.cpp
+++ b/libomnireader/test/test_seekntell.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char* argv[]) {
 
   const char* fname = argv[1];
 
-  OmniReader::Reader* r = OmniReader::GetReader(OmniReader::Format::PlainText);
+  auto r = OmniReader::GetReader(OmniReader::Format::PlainText);
   r->open(fname);
 
   std::cout << r->tell() << "\t";

--- a/omnireader/CMakeLists.txt
+++ b/omnireader/CMakeLists.txt
@@ -1,3 +1,6 @@
+# find fast_float
+find_package(fast_float REQUIRED)
+
 add_cython_target(groreader CXX PY3 groreader.pyx)
 add_library(groreader MODULE ${groreader})
 python_extension_module(groreader)

--- a/omnireader/libomnireader.pxd
+++ b/omnireader/libomnireader.pxd
@@ -1,5 +1,6 @@
 from libcpp cimport bool
 from libcpp.string cimport string as stdstring
+from libcpp.memory cimport unique_ptr
 
 
 cdef extern from "Python.h":
@@ -24,7 +25,7 @@ cdef extern from "omnireader.h" namespace "OmniReader":
         unsigned long long tell()
         bool rewind()
 
-    Reader* GetReader(int f)
+    unique_ptr[Reader] GetReader(int f)
 
 
 cdef extern from "fast_float.h" namespace "fast_float":
@@ -34,7 +35,7 @@ cdef extern from "fast_float.h" namespace "fast_float":
     from_chars_result from_chars[T, UC](const UC *start, const UC* end, T& result)
 
 
-cdef unsigned int strtoint(const char* beg, const char* end):
+cdef inline unsigned int strtoint(const char* beg, const char* end):
     # fixed format file, so ints could be touching other ints, so strtoi can't be used
     # e.g. indices column could be touching the positions column
     cdef unsigned int ret = 0

--- a/omnireader/linesupplier.pyx
+++ b/omnireader/linesupplier.pyx
@@ -1,6 +1,7 @@
 
 from libcpp cimport bool
 from libcpp.string cimport string as stdstring
+from libcpp.memory cimport unique_ptr
 
 import cython
 import numpy as np
@@ -11,10 +12,8 @@ from omnireader.libomnireader cimport (
 
 
 cdef class LineSupplier:
-    cdef Reader *r
+    cdef unique_ptr[Reader] r
 
-    def __cinit__(self):
-        self.r = NULL
 
     def __init__(self, str fname):
         if fname.endswith('bz2'):
@@ -24,20 +23,17 @@ cdef class LineSupplier:
         else:
             self.r = GetReader(Format.PlainText)
 
-        if not self.r.open(bytes(fname, 'utf-8')):
+        if not self.r.get().open(bytes(fname, 'utf-8')):
             raise ValueError
 
-    def __dealloc__(self):
-        if self.r != NULL:
-            del self.r
 
     def get_line(self):
-        cdef stdstring s = self.r.get_line()
+        cdef stdstring s = self.r.get().get_line()
 
         return s
 
     def advance(self):
         cdef bool ret
-        ret = self.r.advance()
+        ret = self.r.get().advance()
 
         return ret

--- a/omnireader/xyzreader.pyx
+++ b/omnireader/xyzreader.pyx
@@ -1,6 +1,8 @@
 
 from libcpp cimport bool
 from libc.stdlib cimport atoi
+from libcpp.memory cimport unique_ptr
+
 
 import cython
 import numpy as np
@@ -49,7 +51,7 @@ cdef void find_spans(const char *start, const char *end,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def read_coords(fname):
-    cdef Reader* r
+    cdef unique_ptr[Reader] r
 
     if fname.endswith('bz2'):
         r = GetReader(Format.BZ2)


### PR DESCRIPTION
This allows us to remove __cinit__ and __dealloc__ methods from the cython classes due to automated reference counting, but has the annoying side effect that cython `.` syntax for pointer access doesn't work and we have to use `.get().XX to access pointer methods. 

I'll let you decide if this is worth it or not @richardjgowers 